### PR TITLE
use SCAN instead of KEYS for llen

### DIFF
--- a/zbx_redis_stats.py
+++ b/zbx_redis_stats.py
@@ -97,9 +97,8 @@ def main():
                 print(client.llen(args.db))
 
             def llensum():
-                keys = client.keys('*')
                 llensum = 0
-                for key in keys:
+                for key in client.scan_iter('*'):
                     if client.type(key) == 'list':
                         llensum += client.llen(key)
                 print(llensum)
@@ -130,9 +129,8 @@ def main():
         for i in server_info:
             a.append(Metric(redis_hostname, ('redis[%s]' % i), server_info[i]))
 
-        keys = client.keys('*')
         llensum = 0
-        for key in keys:
+        for key in client.scan_iter('*'):
             if client.type(key) == 'list':
                 llensum += client.llen(key)
         a.append(Metric(redis_hostname, 'redis[llenall]', llensum))


### PR DESCRIPTION
using scan_iter from redis.py for not blocking the whole redis instance when you have many keys