### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-#zbx_redis_template
+# zbx_redis_template
 
 Zabbix template for Redis (node.js or python)
-##System requirements
+## System requirements
 
 ### For use node.js version script
 - [node.js](https://github.com/joyent/node) 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
